### PR TITLE
BUG - php7.4 issue with trailing comma

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -195,7 +195,7 @@ class Client
         ?int $skip = null,
         ?int $top = null,
         bool $count = false,
-        array $select = [],
+        array $select = []
     ): HttpResponse {
         $params = ['query' => []];
 


### PR DESCRIPTION
It worked in php8, but not 7.4 and below.